### PR TITLE
Bugfix: incompatible character encodings

### DIFF
--- a/lib/docx_replace.rb
+++ b/lib/docx_replace.rb
@@ -13,10 +13,11 @@ module DocxReplace
     end
 
     def replace(pattern, replacement, multiple_occurrences=false)
+      replace = replacement.to_s
       if multiple_occurrences
-        @document_content.force_encoding("UTF-8").gsub!(pattern, replacement)
+        @document_content.force_encoding("UTF-8").gsub!(pattern, replace)
       else
-        @document_content.force_encoding("UTF-8").sub!(pattern, replacement)
+        @document_content.force_encoding("UTF-8").sub!(pattern, replace)
       end
     end
 


### PR DESCRIPTION
I used template for my report with Russian symbols

Error:
incompatible character encodings: ASCII-8BIT and UTF-8

Framework trace part:
….docx_replace/lib/docx_replace.rb:17:in `gsub!'
…/docx_replace/lib/docx_replace.rb:17:in`replace'
