### PR TITLE
Change in `matches` method output

### DIFF
--- a/lib/docx_replace.rb
+++ b/lib/docx_replace.rb
@@ -23,12 +23,16 @@ module DocxReplace
       end
     end
 
-    def matches(pattern)
-      @document_content.scan(pattern).map{|match| match.first}
+    def matches(pattern, unique = false)
+      if unique
+        @document_content.scan(pattern).map{|match| match.first}
+      else
+        @document_content.scan(pattern).flatten.inject(Hash.new(0)) { |hash, key| hash[key] += 1; hash }
+      end
     end
 
     def unique_matches(pattern)
-      matches(pattern)
+      matches(pattern, true)
     end
 
     alias_method :uniq_matches, :unique_matches

--- a/lib/docx_replace/version.rb
+++ b/lib/docx_replace/version.rb
@@ -1,3 +1,3 @@
 module DocxReplace
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
Changes to be committed:
	modified:   lib/docx_replace.rb
	modified:   lib/docx_replace/version.rb

By default method `matches` return the exactly same output as `unique_matches`. Now matches returns a hash of matched values with counted repetitions:
{
	"matched_value_1": 1,
	"matched_value_2": 4
}