### PR TITLE
Replace specials chars with encoded versions

### DIFF
--- a/lib/docx_replace.rb
+++ b/lib/docx_replace.rb
@@ -15,7 +15,7 @@ module DocxReplace
     end
 
     def replace(pattern, replacement, multiple_occurrences=false)
-      replace = replacement.to_s
+      replace = CGI.escapeHTML(replacement.to_s)
       if multiple_occurrences
         @document_content.force_encoding("UTF-8").gsub!(pattern, replace)
       else


### PR DESCRIPTION
Having characters like & in the replacement text would corrupt the documents (Microsoft Word could not open them, LibreOffice Writer could). This commit replaces them correctly.
