### PR TITLE
fixed some xml special character export to docx file, cause open case…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ rdoc
 spec/reports
 test/tmp
 test/version_tmp
+.idea
 tmp
 *.swp
 .DS_Store

--- a/lib/docx_replace.rb
+++ b/lib/docx_replace.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 
-require "docx_replace/version"
+require 'docx_replace/version'
 require 'zip'
 require 'tempfile'
 
@@ -15,11 +15,11 @@ module DocxReplace
     end
 
     def replace(pattern, replacement, multiple_occurrences=false)
-      replace = replacement.to_s
+      replace = replacement.to_s.encode(xml: :text)
       if multiple_occurrences
-        @document_content.force_encoding("UTF-8").gsub!(pattern, replace)
+        @document_content.force_encoding('UTF-8').gsub!(pattern, replace)
       else
-        @document_content.force_encoding("UTF-8").sub!(pattern, replace)
+        @document_content.force_encoding('UTF-8').sub!(pattern, replace)
       end
     end
 


### PR DESCRIPTION
fixed replace value have some special character that not support in xml issue,
sample:

have char "&" will be replace in docx template file,
when exported and then open it .
some soft will be exception like apple's pages
i google found that char "&" not supoort in xml file should be convert to "&amp;". 
[you can found it](https://codedecoder.wordpress.com/2013/06/03/escaping-removing-or-encoding-special-characters-xml-ruby/)
