### PR TITLE
Encode replacements to be xml safe

### DIFF
--- a/lib/docx_replace.rb
+++ b/lib/docx_replace.rb
@@ -15,7 +15,7 @@ module DocxReplace
     end
 
     def replace(pattern, replacement, multiple_occurrences=false)
-      replace = replacement.to_s
+      replace = replacement.to_s.encode(xml: :text)
       if multiple_occurrences
         @document_content.force_encoding("UTF-8").gsub!(pattern, replace)
       else


### PR DESCRIPTION
Hi there!
### The case is
Trying to write back to zip file results in a corrupted docx file if replacements contain characters like `&` (i.e. you want to replace company names with smth like *Rambler&Co*).

### I suggest
Converting strings into *xml-safe* format before replacements.
That is, a string `&` will be converted into string `&amp;` which is parsed smoothly in xml format.

Thanks in advance.