### PR TITLE
Add support for Office 365 files

### DIFF
--- a/lib/docx_replace/version.rb
+++ b/lib/docx_replace/version.rb
@@ -1,3 +1,3 @@
 module DocxReplace
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end


### PR DESCRIPTION
Office 365 generates documents which may has no ```word/document.xml```, but a ```word/document2.xml``` (and so on). I you try to process such document with current version of docx_replace you'll get ```Errno::ENOENT: No such file or directory - word/document.xml```
To resolve this issue I've made changes to get document file path from ```[Content_Types].xml```